### PR TITLE
Unify GitHub project references

### DIFF
--- a/OnlinePayments.Sdk.IntegrationTests/OnlinePayments.Sdk.IntegrationTests.csproj
+++ b/OnlinePayments.Sdk.IntegrationTests/OnlinePayments.Sdk.IntegrationTests.csproj
@@ -12,11 +12,11 @@
     <PackageTags>Online Payments SDK</PackageTags>
     <Copyright>Copyright (c) 2020 Ingenico e-Commerce Solutions B.V..</Copyright>
     <Authors>Online Payments</Authors>
-    <PackageProjectUrl>https://github.com/Online-Payments/dotnet/</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/wl-online-payments-direct/sdk-dotnet/</PackageProjectUrl>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageIcon>packageIcon.png</PackageIcon>
-    <PackageIconUrl>https://github.com/Online-Payments/sdk-dotnet/blob/master/packageIcon.png</PackageIconUrl>
-    <RepositoryUrl>https://github.com/Online-Payments/sdk-dotnet</RepositoryUrl>
+    <PackageIconUrl>https://github.com/wl-online-payments-direct/sdk-dotnet/blob/master/packageIcon.png</PackageIconUrl>
+    <RepositoryUrl>https://github.com/wl-online-payments-direct/sdk-dotnet</RepositoryUrl>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/OnlinePayments.Sdk.StrongName/OnlinePayments.Sdk.StrongName.csproj
+++ b/OnlinePayments.Sdk.StrongName/OnlinePayments.Sdk.StrongName.csproj
@@ -12,12 +12,12 @@
     <PackageTags>Online Payments SDK</PackageTags>
     <Copyright>Copyright (c) 2020 Ingenico e-Commerce Solutions B.V..</Copyright>
     <Authors>Online Payments</Authors>
-    <PackageProjectUrl>https://github.com/Online-Payments/dotnet/</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/wl-online-payments-direct/sdk-dotnet/</PackageProjectUrl>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>packageIcon.png</PackageIcon>
-    <PackageIconUrl>https://github.com/Online-Payments/sdk-dotnet/blob/master/packageIcon.png</PackageIconUrl>
-    <RepositoryUrl>https://github.com/Online-Payments/sdk-dotnet</RepositoryUrl>
+    <PackageIconUrl>https://github.com/wl-online-payments-direct/sdk-dotnet/blob/master/packageIcon.png</PackageIconUrl>
+    <RepositoryUrl>https://github.com/wl-online-payments-direct/sdk-dotnet</RepositoryUrl>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\OnlinePayments.Sdk.keypair.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>

--- a/OnlinePayments.Sdk.Tests/OnlinePayments.Sdk.Tests.csproj
+++ b/OnlinePayments.Sdk.Tests/OnlinePayments.Sdk.Tests.csproj
@@ -12,11 +12,11 @@
     <PackageTags>Online Payments SDK</PackageTags>
     <Copyright>Copyright (c) 2020 Ingenico e-Commerce Solutions B.V..</Copyright>
     <Authors>Online Payments</Authors>
-    <PackageProjectUrl>https://github.com/Online-Payments/dotnet/</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/wl-online-payments-direct/sdk-dotnet/</PackageProjectUrl>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageIcon>packageIcon.png</PackageIcon>
-    <PackageIconUrl>https://github.com/Online-Payments/sdk-dotnet/blob/master/packageIcon.png</PackageIconUrl>
-    <RepositoryUrl>https://github.com/Online-Payments/sdk-dotnet</RepositoryUrl>
+    <PackageIconUrl>https://github.com/wl-online-payments-direct/sdk-dotnet/blob/master/packageIcon.png</PackageIconUrl>
+    <RepositoryUrl>https://github.com/wl-online-payments-direct/sdk-dotnet</RepositoryUrl>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/OnlinePayments.Sdk/OnlinePayments.Sdk.csproj
+++ b/OnlinePayments.Sdk/OnlinePayments.Sdk.csproj
@@ -12,12 +12,12 @@
     <PackageTags>Online Payments SDK</PackageTags>
     <Copyright>Copyright (c) 2020 Ingenico e-Commerce Solutions B.V..</Copyright>
     <Authors>Online Payments</Authors>
-    <PackageProjectUrl>https://github.com/Online-Payments/dotnet/</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/wl-online-payments-direct/sdk-dotnet/</PackageProjectUrl>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>packageIcon.png</PackageIcon>
-    <PackageIconUrl>https://github.com/Online-Payments/sdk-dotnet/blob/master/packageIcon.png</PackageIconUrl>
-    <RepositoryUrl>https://github.com/Online-Payments/sdk-dotnet</RepositoryUrl>
+    <PackageIconUrl>https://github.com/wl-online-payments-direct/sdk-dotnet/blob/master/packageIcon.png</PackageIconUrl>
+    <RepositoryUrl>https://github.com/wl-online-payments-direct/sdk-dotnet</RepositoryUrl>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The .NET SDK helps you to communicate with the Online Payments Server API. Its p
 * handling of all the details concerning authentication
 * handling of required metadata
 
-See the [Online Payments Developer Hub](https://github.com/Online-Payments/dotnet/) for more information on how to use the SDK.
+See the [Online Payments Developer Hub](https://github.com/wl-online-payments-direct/sdk-dotnet/) for more information on how to use the SDK.
 
 ## Structure of this repository
 This repository consists out of three main components:


### PR DESCRIPTION
The repository contains some broken references, for instance in the README file:

> https://github.com/Online-Payments/dotnet/

Also, there are some references to `https://github.com/Online-Payments/sdk-dotnet`, which I changed to `https://github.com/wl-online-payments-direct/sdk-dotnet`. If this is wrong, I'll remove those changes.